### PR TITLE
chore: remove separate group/PR for eik modules

### DIFF
--- a/sub-level-module.json
+++ b/sub-level-module.json
@@ -17,22 +17,6 @@
       }
     },
     {
-      "groupName": "Semantic Release packages",
-      "packagePatterns": ["^@semantic-release/", "semantic-release"]
-    },
-    {
-      "groupName": "ESlint and Prettier packages",
-      "packagePatterns": [
-        "eslint-config-airbnb-base",
-        "eslint-config-prettier",
-        "eslint-plugin-prettier",
-        "eslint-plugin-import",
-        "@babel/eslint-parser",
-        "prettier",
-        "eslint"
-      ]
-    },
-    {
       "groupName": "Eik packages",
       "packagePatterns": ["^@eik/"]
     }

--- a/top-level-module.json
+++ b/top-level-module.json
@@ -16,26 +16,6 @@
       "major": {
         "automerge": false
       }
-    },
-    {
-      "groupName": "Semantic Release packages",
-      "packagePatterns": ["^@semantic-release/", "semantic-release"]
-    },
-    {
-      "groupName": "ESlint and Prettier packages",
-      "packagePatterns": [
-        "eslint-config-airbnb-base",
-        "eslint-config-prettier",
-        "eslint-plugin-prettier",
-        "eslint-plugin-import",
-        "@babel/eslint-parser",
-        "prettier",
-        "eslint"
-      ]
-    },
-    {
-      "groupName": "Eik packages",
-      "packagePatterns": ["^@eik/"]
     }
   ]
 }


### PR DESCRIPTION
We often end up with two releases every monday. One for external dependencies and another for Eik dependencies. Get them all in one.